### PR TITLE
Update to Meilisearch 0.28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ erl_crash.dump
 priv/plts/*
 !priv/plts/.gitkeep
 .vscode
+TODO.md

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
-elixir 1.12.2-otp-24
 elixir 1.13.4-otp-25
+elixir 1.12.2-otp-24
+erlang 25.0.3
 erlang 24.0.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 elixir 1.12.2-otp-24
+elixir 1.13.4-otp-25
 erlang 24.0.1

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
-import_config "#{Mix.env()}.exs"
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :meilisearch,
   # Latest version from docker-compose.yml

--- a/lib/meilisearch/documents.ex
+++ b/lib/meilisearch/documents.ex
@@ -37,34 +37,44 @@ defmodule Meilisearch.Documents do
 
       iex> Meilisearch.Documents.list("meilisearch_test")
       {:ok,
-        [
-          %{
-            "id" => 2,
-            "tagline" => "You'll never go in the water again",
-            "title" => "Jaws"
-          },
-          %{
-            "id" => 1,
-            "tagline" => "In space no one can hear you scream",
-            "title" => "Alien"
-          }
-        ]
+        %{ 
+          "total" => 2,
+          "limit" => 20,
+          "offset" => 0,
+          "results" => [
+            %{
+              "id" => 2,
+              "tagline" => "You'll never go in the water again",
+              "title" => "Jaws"
+            },
+            %{
+              "id" => 1,
+              "tagline" => "In space no one can hear you scream", 
+              "title" => "Alien"
+            }
+          ]
+        }
       }
 
       iex> Meilisearch.Documents.get("meilisearch_test", limit: 2, offset: 4)
       {:ok,
-        [
-          %{
-            "id" => 6,
-            "tagline" => "Who ya gonna call?",
-            "title" => "Ghostbusters"
-          },
-          %{
-            "id" => 5,
-            "tagline" => "Be Afraid. Be very afraid.",
-            "title" => "The Fly"
-          }
-        ]
+        %{ 
+          "total" => 2,
+          "limit" => 2,
+          "offset" => 4,
+          "results" => [
+            %{
+              "id" => 6,
+              "tagline" => "Who ya gonna call?",
+              "title" => "Ghostbusters"
+            },
+            %{
+              "id" => 5,
+              "tagline" => "Be Afraid. Be very afraid.",
+              "title" => "The Fly"
+            }
+          ] 
+        }
       }
   """
   @spec list(String.t(), Keyword.t()) :: HTTP.response()
@@ -84,7 +94,7 @@ defmodule Meilisearch.Documents do
         "tagline" => "You'll never go in the water again",
         "title" => "Jaws"
       })
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
 
       iex> Meilisearch.Documents.add_or_replace(
         "meilisearch_test",
@@ -101,7 +111,7 @@ defmodule Meilisearch.Documents do
           }
         ]
       )
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
 
   @spec add_or_replace(String.t(), list(any), Keyword.t()) :: HTTP.response()
@@ -127,7 +137,7 @@ defmodule Meilisearch.Documents do
         "tagline" => "You'll never go in the water again",
         "title" => "Jaws"
       })
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
 
       iex> Meilisearch.Documents.add_or_update(
         "meilisearch_test",
@@ -144,7 +154,7 @@ defmodule Meilisearch.Documents do
           }
         ]
       )
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec add_or_update(String.t(), list(any), Keyword.t()) :: {:ok, any} | {:error, String.t()}
   def add_or_update(index_uid, docs, opts \\ [])
@@ -163,10 +173,10 @@ defmodule Meilisearch.Documents do
   ## Example
 
       iex> Meilisearch.Documents.delete("meilisearch_test", 1)
-      {:ok, %{"updateId" => 0}}
+      {:ok, %{"taskUid" => 0}}
 
       iex> Meilisearch.Documents.delete("meilisearch_test", [1,2,3,4])
-      {:ok, %{"updateId" => 0}}
+      {:ok, %{"taskUid" => 0}}
   """
 
   @spec delete(String.t(), String.t() | list(String.t())) :: {:ok, any} | {:error, String.t()}
@@ -184,7 +194,7 @@ defmodule Meilisearch.Documents do
   ## Example
 
       iex> Meilisearch.Documents.delete_all("meilisearch_test")
-      {:ok, %{"updateId" => 0}}
+      {:ok, %{"taskUid" => 0}}
 
   """
   @spec delete_all(String.t()) :: {:ok, any} | {:error, binary}

--- a/lib/meilisearch/http.ex
+++ b/lib/meilisearch/http.ex
@@ -27,6 +27,13 @@ defmodule Meilisearch.HTTP do
     |> handle_response()
   end
 
+  @spec patch_request(String.t(), any, any, Keyword.t()) :: response()
+  def patch_request(url, body, headers \\ [], options \\ []) do
+    url
+    |> patch(body, headers, options)
+    |> handle_response()
+  end
+
   @spec post_request(String.t(), any, any, Keyword.t()) :: response()
   def post_request(url, body, headers \\ [], options \\ []) do
     url
@@ -68,9 +75,8 @@ defmodule Meilisearch.HTTP do
 
   # Utils
 
-  defp handle_response({:ok, %HTTPoison.Response{body: body, status_code: status_code} = resp})
+  defp handle_response({:ok, %HTTPoison.Response{body: body, status_code: status_code}})
   when status_code in 400..599 do
-    IO.inspect(resp)
     message = Map.get(body, "message")
     {:error, status_code, message}
   end

--- a/lib/meilisearch/http.ex
+++ b/lib/meilisearch/http.ex
@@ -89,6 +89,7 @@ defmodule Meilisearch.HTTP do
   defp add_auth_header(headers) do
     api_key = Meilisearch.Config.api_key()
 
-    [{"X-Meili-API-Key", api_key} | headers]
+    # < v0.24, use: [{"X-Meili-API-Key", api_key} | headers]
+    [{"Authorization", "Bearer #{api_key}"} | headers]
   end
 end

--- a/lib/meilisearch/http.ex
+++ b/lib/meilisearch/http.ex
@@ -68,8 +68,9 @@ defmodule Meilisearch.HTTP do
 
   # Utils
 
-  defp handle_response({:ok, %HTTPoison.Response{body: body, status_code: status_code}})
-       when status_code in 400..599 do
+  defp handle_response({:ok, %HTTPoison.Response{body: body, status_code: status_code} = resp})
+  when status_code in 400..599 do
+    IO.inspect(resp)
     message = Map.get(body, "message")
     {:error, status_code, message}
   end

--- a/lib/meilisearch/indexes.ex
+++ b/lib/meilisearch/indexes.ex
@@ -26,7 +26,10 @@ defmodule Meilisearch.Indexes do
   """
   @spec list :: HTTP.response()
   def list do
-    HTTP.get_request("indexes")
+    case HTTP.get_request("indexes") do
+      {:ok, %{ "results" => indexes }} -> {:ok, indexes}
+      error -> error
+    end
   end
 
   @doc """

--- a/lib/meilisearch/indexes.ex
+++ b/lib/meilisearch/indexes.ex
@@ -16,7 +16,6 @@ defmodule Meilisearch.Indexes do
       {:ok, [
         %{
           "createdAt" => "2020-05-23T06:20:18.394281328Z",
-          "name" => "meilisearch_test",
           "primaryKey" => nil,
           "uid" => "meilisearch_test",
           "updatedAt" => "2020-05-23T06:20:18.394292399Z"
@@ -41,7 +40,6 @@ defmodule Meilisearch.Indexes do
       {:ok,
         %{
           "createdAt" => "2020-05-23T06:20:18.394281328Z",
-          "name" => "meilisearch_test",
           "primaryKey" => nil,
           "uid" => "meilisearch_test",
           "updatedAt" => "2020-05-23T06:20:18.394292399Z"
@@ -63,23 +61,23 @@ defmodule Meilisearch.Indexes do
 
       iex> Meilisearch.Indexes.create("meilisearch_test")
       {:ok,
-        %{
-          "createdAt" => "2020-05-23T06:20:18.394281328Z",
-          "name" => "meilisearch_test",
-          "primaryKey" => nil,
-          "uid" => "meilisearch_test",
-          "updatedAt" => "2020-05-23T06:20:18.394292399Z"
+        {
+          "taskUid" => 0,
+          "indexUid" => "meilisearch_test",
+          "status" => "enqueued",
+          "type" => "indexCreation",
+          "enqueuedAt" => "2021-08-12T10:00:00.000000Z"
         }
       }
 
       iex> Meilisearch.create("meilisearch_test", primary_key: "key_name")
       {:ok,
-        %{
-          "createdAt" => "2020-05-23T06:20:18.394281328Z",
-          "name" => "meilisearch_test",
-          "primaryKey" => "key_name",
-          "uid" => "meilisearch_test",
-          "updatedAt" => "2020-05-23T06:20:18.394292399Z"
+        {
+          "taskUid" => 0,
+          "indexUid" => "meilisearch_test",
+          "status" => "enqueued",
+          "type" => "indexCreation",
+          "enqueuedAt" => "2021-08-12T10:00:00.000000Z"
         }
       }
   """
@@ -103,11 +101,11 @@ defmodule Meilisearch.Indexes do
       iex> Meilisearch.Indexes.update("meilisearch_test", primary_key: "new_key")
       {:ok,
         %{
-          "primaryKey" => "new_primary_key",
-          "createdAt" => "2020-05-25T04:30:10.681720067Z",
-          "name" => "meilisearch_test",
-          "uid" => "meilisearch_test",
-          "updatedAt" => "2020-05-25T04:30:10.685540577Z"
+          "taskUid": 1,
+          "indexUid": "meilisearch_test",
+          "status": "enqueued",
+          "type": "indexUpdate",
+          "enqueuedAt": "2021-08-12T10:00:00.000000Z"
         }
       }
   """
@@ -115,7 +113,7 @@ defmodule Meilisearch.Indexes do
   def update(uid, opts \\ []) do
     with {:ok, primary_key} <- Keyword.fetch(opts, :primary_key),
          body <- %{primaryKey: primary_key} do
-      HTTP.put_request("indexes/#{uid}", body)
+      HTTP.patch_request("indexes/#{uid}", body)
     else
       _ -> {:error, "primary_key is required"}
     end
@@ -127,10 +125,14 @@ defmodule Meilisearch.Indexes do
   ## Examples
 
       iex> Meilisearch.Indexes.delete("meilisearch_test")
-      {:ok, nil}
-
-      iex> Meilisearch.delete("nonexistent_index")
-      {:error, 404, Index meilisearch_test not found"}
+      {:ok, 
+        %{
+          "taskUid": 1,
+          "indexUid": "movies",
+          "status": "enqueued",
+          "type": "indexDeletion",
+          "enqueuedAt": "2021-08-12T10:00:00.000000Z"
+        }}
   """
   @spec delete(String.t()) :: HTTP.response()
   def delete(uid) do

--- a/lib/meilisearch/keys.ex
+++ b/lib/meilisearch/keys.ex
@@ -13,10 +13,47 @@ defmodule Meilisearch.Keys do
       iex> Meilisearch.Keys.get()
       {:ok,
         %{
-          "private" => "abcdefghijklmnopqrstuvwxyz1234567890",
-          "public" => "1234567890abcdefghijklmnopqrstuvwxyz"
-        }
-      }
+          "results" => [
+            %{ 
+              "name" => null,
+              "description" => "Manage documents: Products/Reviews API key",
+              "key" => "d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4",
+              "uid" => "6062abda-a5aa-4414-ac91-ecd7944c0f8d",
+              "actions" => [
+                "documents.add",
+                "documents.delete"
+              ],
+              "indexes" => [ "products", "reviews" ],
+              "expiresAt" => "2021-12-31T23:59:59Z",
+              "createdAt" => "2021-10-12T00:00:00Z",
+              "updatedAt" => "2021-10-13T15:00:00Z"
+            },
+            %{
+              "name" => "Default Search API Key",
+              "description" => "Use it to search from the frontend code",
+              "key" => "0a6e572506c52ab0bd6195921575d23092b7f0c284ab4ac86d12346c33057f99",
+              "uid" => "74c9c733-3368-4738-bbe5-1d18a5fecb37",
+              "actions" => [ "search" ],
+              "indexes" => [ "*" ],
+              "expiresAt" => null,
+              "createdAt" => "2021-08-11T10:00:00Z",
+              "updatedAt" => "2021-08-11T10:00:00Z"
+            },
+            %{
+              "name" => "Default Admin API Key",
+              "description" => "Use it for anything that is not a search operation. Caution! Do not expose it on a public frontend",
+              "key" => "380689dd379232519a54d15935750cc7625620a2ea2fc06907cb40ba5b421b6f",
+              "uid" => "20f7e4c4-612c-4dd1-b783-7934cc038213",
+              "actions" => [ "*" ],
+              "indexes" => [ "*" ],
+              "expiresAt" => null,
+              "createdAt" => "2021-08-11T10:00:00Z",
+              "updatedAt" => "2021-08-11T10:00:00Z"
+            }],
+            "offset" => 0,
+            "limit" => 3,
+            "total" => 7
+            }
   """
   @spec get() :: HTTP.response()
   def get do

--- a/lib/meilisearch/settings.ex
+++ b/lib/meilisearch/settings.ex
@@ -12,24 +12,37 @@ defmodule Meilisearch.Settings do
 
   ## Example
 
-      iex> Meilisearch.Settings.get("meilisearch_test")
-      {:ok,
+    iex> Meilisearch.Settings.get("meilisearch_test")
+    {:ok,
       %{
+        "displayedAttributes" => [ "*" ],
+        "searchableAttributes" => [ "*" ],
+        "filterableAttributes" => [],
+        "sortableAttributes" => [],
         "rankingRules" => [
-          "typo",
           "words",
+          "typo",
           "proximity",
           "attribute",
-          "wordsPosition",
+          "sort",
           "exactness"
         ],
-        "attributesForFaceting" => [],
-        "displayedAttributes" => ["*"],
-        "distinctAttribute" => "id",
-        "searchableAttributes" => ["*"],
         "stopWords" => [],
-        "synonyms" => %{}
-      }}
+        "synonyms" => %{},
+        "distinctAttribute" => null,
+        "typoTolerance" => %{
+          "enabled" => true,
+          "minWordSizeForTypos" => {
+            "oneTypo" => 5,
+            "twoTypos" => 9
+          },
+          "disableOnWords" => [],
+          "disableOnAttributes" => []
+        },
+        "faceting" => %{ "maxValuesPerFacet" => 100 },
+        "pagination" => %{ "maxTotalHits" => 1000 }
+      }
+    }
   """
   @spec get(String.t()) :: HTTP.response()
   def get(index_uid) do
@@ -42,11 +55,11 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.update("meilisearch_test", %{synonyms: %{alien: ["ufo"]}})
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec update(String.t(), any()) :: HTTP.response()
   def update(index_uid, settings \\ %{}) do
-    HTTP.post_request("indexes/#{index_uid}/settings", settings)
+    HTTP.patch_request("indexes/#{index_uid}/settings", settings)
   end
 
   @doc """
@@ -55,7 +68,7 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.reset("meilisearch_test")
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec reset(String.t()) :: HTTP.response()
   def reset(index_uid) do
@@ -68,7 +81,19 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.get_synonyms("meilisearch_test")
-      {:ok, %{}}
+      {:ok, %{
+        "wolverine" => [
+          "xmen",
+          "logan"
+        ],
+        "logan" => [
+          "wolverine",
+          "xmen"
+        ],
+        "wow" => [
+          "world of warcraft"
+        ]
+      }}
   """
   @spec get_synonyms(String.t()) :: HTTP.response()
   def get_synonyms(index_uid) do
@@ -81,11 +106,11 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.update_synonyms("meilisearch_test", %{alien: ["ufo"]})
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec update_synonyms(String.t(), any()) :: HTTP.response()
   def update_synonyms(index_uid, synonyms) do
-    HTTP.post_request("indexes/#{index_uid}/settings/synonyms", synonyms)
+    HTTP.put_request("indexes/#{index_uid}/settings/synonyms", synonyms)
   end
 
   @doc """
@@ -94,7 +119,7 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.reset_synonyms("meilisearch_test")
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec reset_synonyms(String.t()) :: HTTP.response()
   def reset_synonyms(index_uid) do
@@ -120,11 +145,11 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.update_stop_words("meilisearch_test", ["the", "of", "to"])
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec update_stop_words(String.t(), list(String.t())) :: HTTP.response()
   def update_stop_words(index_uid, stop_words) do
-    HTTP.post_request("indexes/#{index_uid}/settings/stop-words", stop_words)
+    HTTP.put_request("indexes/#{index_uid}/settings/stop-words", stop_words)
   end
 
   @doc """
@@ -133,7 +158,7 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.reset_stop_words("meilisearch_test")
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec reset_stop_words(String.t()) :: HTTP.response()
   def reset_stop_words(index_uid) do
@@ -174,7 +199,7 @@ defmodule Meilisearch.Settings do
   """
   @spec update_ranking_rules(String.t(), list(String.t())) :: HTTP.response()
   def update_ranking_rules(index_uid, ranking_rules) do
-    HTTP.post_request("indexes/#{index_uid}/settings/ranking-rules", ranking_rules)
+    HTTP.put_request("indexes/#{index_uid}/settings/ranking-rules", ranking_rules)
   end
 
   @doc """
@@ -191,48 +216,99 @@ defmodule Meilisearch.Settings do
   end
 
   @doc """
-  Get attributes for faceting.
+  Get maxValuesPerFacet setting.
 
   ## Example
 
-      iex> Meilisearch.Settings.get_attributes_for_faceting("meilisearch_test")
-      {:ok, []}
+    iex> Meilisearch.Settings.get_faceting("meilisearch_test")
+    {:ok,
+      %{ "maxValuesPerFacet" => 100 }
+    }
   """
-  @spec get_attributes_for_faceting(String.t()) :: HTTP.response()
-  def get_attributes_for_faceting(index_uid) do
-    HTTP.get_request("indexes/#{index_uid}/settings/attributes-for-faceting")
+  @spec get_faceting(String.t()) :: HTTP.response()
+  def get_faceting(index_uid) do
+    HTTP.get_request("indexes/#{index_uid}/settings/faceting")
   end
 
   @doc """
-  Update attributes for faceting.
+  Update maxValuesPerFacet setting.
 
   ## Example
 
-      iex> Meilisearch.Settings.update_attributes_for_faceting(
+      iex> Meilisearch.Settings.update_faceting(
         "meilisearch_test",
-        ["title"]
+        %{ maxValuesPerFacet: 2 }
       )
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
-  @spec update_attributes_for_faceting(String.t(), list(String.t())) :: HTTP.response()
-  def update_attributes_for_faceting(index_uid, attributes_for_faceting) do
-    HTTP.post_request(
-      "indexes/#{index_uid}/settings/attributes-for-faceting",
-      attributes_for_faceting
+  @spec update_faceting(String.t(), map()) :: HTTP.response()
+  def update_faceting(index_uid, faceting_settings) do
+    HTTP.patch_request(
+      "indexes/#{index_uid}/settings/faceting",
+      faceting_settings
     )
   end
 
   @doc """
-  Reset attributes for faceting.
+  Reset maxValuesPerFacet setting.
 
   ## Example
 
-      iex> Meilisearch.Settings.reset_attributes_for_faceting("meilisearch_test")
-      {:ok, %{"updateId" => 1}}
+      iex> Meilisearch.Settings.reset_faceting("meilisearch_test")
+      {:ok, %{"taskUid" => 1}}
   """
-  @spec reset_attributes_for_faceting(String.t()) :: HTTP.response()
-  def reset_attributes_for_faceting(index_uid) do
-    HTTP.delete_request("indexes/#{index_uid}/settings/attributes-for-faceting")
+  @spec reset_faceting(String.t()) :: HTTP.response()
+  def reset_faceting(index_uid) do
+    HTTP.delete_request("indexes/#{index_uid}/settings/faceting")
+  end
+
+  @doc """
+  Get attributes for filtering & faceting.
+
+  ## Example
+
+      iex> Meilisearch.Settings.get_filterable_attributes("meilisearch_test")
+      {:ok, [
+        "genres",
+        "directors",
+        "release_date.year"
+      ]}
+  """
+  @spec get_filterable_attributes(String.t()) :: HTTP.response()
+  def get_filterable_attributes(index_uid) do
+    HTTP.get_request("indexes/#{index_uid}/settings/filterable-attributes")
+  end
+
+  @doc """
+  Update attributes for filtering & faceting.
+
+  ## Example
+
+      iex> Meilisearch.Settings.update_filterable_attributes(
+        "meilisearch_test",
+        ["title"]
+      )
+      {:ok, %{"taskUid" => 1}}
+  """
+  @spec update_filterable_attributes(String.t(), list(String.t())) :: HTTP.response()
+  def update_filterable_attributes(index_uid, filterable_attributes) do
+    HTTP.put_request(
+      "indexes/#{index_uid}/settings/filterable-attributes",
+      filterable_attributes
+    )
+  end
+
+  @doc """
+  Reset attributes for filtering & faceting.
+
+  ## Example
+
+      iex> Meilisearch.Settings.reset_filterable_attributes("meilisearch_test")
+      {:ok, %{"taskUid" => 1}}
+  """
+  @spec reset_filterable_attributes(String.t()) :: HTTP.response()
+  def reset_filterable_attributes(index_uid) do
+    HTTP.delete_request("indexes/#{index_uid}/settings/filterable-attributes")
   end
 
   @doc """
@@ -254,11 +330,11 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.update_distinct_attribute("meilisearch_test", "id")
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec update_distinct_attribute(String.t(), String.t()) :: HTTP.response()
   def update_distinct_attribute(index_uid, distinct_attribute) do
-    HTTP.post_request(
+    HTTP.put_request(
       "indexes/#{index_uid}/settings/distinct-attribute",
       distinct_attribute
     )
@@ -270,7 +346,7 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.reset_distinct_attribute("meilisearch_test")
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec reset_distinct_attribute(String.t()) :: HTTP.response()
   def reset_distinct_attribute(index_uid) do
@@ -296,11 +372,11 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.update_searchable_attributes("meilisearch_test", ["title"])
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec update_searchable_attributes(String.t(), list(String.t())) :: HTTP.response()
   def update_searchable_attributes(index_uid, searchable_attributes) do
-    HTTP.post_request(
+    HTTP.put_request(
       "indexes/#{index_uid}/settings/searchable-attributes",
       searchable_attributes
     )
@@ -338,11 +414,11 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.update_displayed_attributes("meilisearch_test", ["title"])
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec update_displayed_attributes(String.t(), list(String.t())) :: HTTP.response()
   def update_displayed_attributes(index_uid, displayed_attributes) do
-    HTTP.post_request(
+    HTTP.put_request(
       "indexes/#{index_uid}/settings/displayed-attributes",
       displayed_attributes
     )
@@ -354,7 +430,7 @@ defmodule Meilisearch.Settings do
   ## Example
 
       iex> Meilisearch.Settings.reset_displayed_attributes("meilisearch_test")
-      {:ok, %{"updateId" => 1}}
+      {:ok, %{"taskUid" => 1}}
   """
   @spec reset_displayed_attributes(String.t()) :: HTTP.response()
   def reset_displayed_attributes(index_uid) do

--- a/lib/meilisearch/stats.ex
+++ b/lib/meilisearch/stats.ex
@@ -13,7 +13,7 @@ defmodule Meilisearch.Stats do
   ## Example
 
       iex> Meilisearch.Stats.get("meilisearch_test")
-      {:ok, %{"fieldsFrequency" => %{}, "isIndexing" => false, "numberOfDocuments" => 0}}
+      {:ok, %{"fieldFrequency" => %{}, "isIndexing" => false, "numberOfDocuments" => 0}}
 
   """
   @spec get(String.t()) :: HTTP.response()

--- a/lib/meilisearch/tasks.ex
+++ b/lib/meilisearch/tasks.ex
@@ -1,17 +1,17 @@
-defmodule Meilisearch.Updates do
+defmodule Meilisearch.Tasks do
   @moduledoc """
-  Collection of functions used to get information about the progress of updates.
+  Collection of functions used to get information about the progress of enqueued tasks.
 
-  [MeiliSearch Documentation - Updates](https://docs.meilisearch.com/references/updates.html)
+  [MeiliSearch Documentation - Updates](https://docs.meilisearch.com/references/tasks.html)
   """
 
   alias Meilisearch.HTTP
 
   @doc """
-  Get the status of individual update.
+  Get the status of individual task.
 
   ## Example
-      iex> Meilisearch.Updates.get(1)
+      iex> Meilisearch.Tasks.get(1)
       {:ok,
         %{
           "uid" => 1,
@@ -30,12 +30,12 @@ defmodule Meilisearch.Updates do
       }
   """
   @spec get(String.t() | integer) :: HTTP.response()
-  def get(update_id) do
-    HTTP.get_request("tasks/#{update_id}")
+  def get(task_id) do
+    HTTP.get_request("tasks/#{task_id}")
   end
 
   @doc """
-  Get the status of all updates.
+  Get the status of all tasks.
 
   ## Example
       iex> Meilisearch.Updates.list()
@@ -74,16 +74,16 @@ defmodule Meilisearch.Updates do
   @spec list() :: HTTP.response()
   def list() do
     case HTTP.get_request("tasks") do
-      {:ok, %{ "results" => updates }} -> {:ok, updates}
+      {:ok, %{ "results" => tasks }} -> {:ok, tasks}
       error -> error
     end
   end
 
   @doc """
-  Get the status of all updates for a given index.
+  Get the status of all tasks for a given index.
 
   ## Example
-      iex> Meilisearch.Updates.list(index_uid)
+      iex> Meilisearch.Tasks.list(index_uid)
       {:ok,
         [
           %{
@@ -119,7 +119,7 @@ defmodule Meilisearch.Updates do
   @spec list(String.t) :: HTTP.response()
   def list(index_uid) do
     case HTTP.get_request("tasks?indexUid=#{index_uid}") do
-      {:ok, %{ "results" => updates }} -> {:ok, updates}
+      {:ok, %{ "results" => tasks }} -> {:ok, tasks}
       error -> error
     end
   end

--- a/lib/meilisearch/tasks.ex
+++ b/lib/meilisearch/tasks.ex
@@ -124,4 +124,44 @@ defmodule Meilisearch.Tasks do
     end
   end
 
+  @doc """
+  Await the resolution of an async task. Keeps trying in `for_milli` intervals (default is 250ms).
+
+  # Example
+
+    iex> Meilisearch.Tasks.await_result(1)
+    {:ok,
+      %{ 
+        "uid" => 4,
+        "indexUid"  =>"movie",
+        "status" => "failed",
+        "type" => "indexDeletion",
+        "details" => %{
+          "deletedDocuments" => 0
+        },
+        "error" => %{
+          "message" => "Index `movie` not found.",
+          "code" => "index_not_found",
+          "type" => "invalid_request",
+          "link" => "https://docs.meilisearch.com/errors#index_not_found"
+        },
+        "duration" => "PT0.001192S",
+        "enqueuedAt" => "2022-08-04T12:28:15.159167Z",
+        "startedAt" => "2022-08-04T12:28:15.161996Z",
+        "finishedAt" => "2022-08-04T12:28:15.163188Z"
+      }
+    }
+  """
+  @spec await_result(String.t) :: HTTP.response()
+  def await_result(task_uid, for_milli \\ 250) do
+    case get(task_uid) do
+      {:ok, %{"status" => status}} when status in ["enqueued", "processing"] -> 
+        :timer.sleep(for_milli)
+        await_result(task_uid, for_milli)
+
+      message ->
+        message
+    end
+  end
+
 end

--- a/lib/meilisearch/updates.ex
+++ b/lib/meilisearch/updates.ex
@@ -8,45 +8,120 @@ defmodule Meilisearch.Updates do
   alias Meilisearch.HTTP
 
   @doc """
-  Get the status of individual update for given index.
+  Get the status of individual update.
 
   ## Example
-      iex> Meilisearch.Updates.get("meilisearch_test", 1)
+      iex> Meilisearch.Updates.get(1)
       {:ok,
         %{
+          "uid" => 1,
+          "indexUid" => "test_index",
+          "status" => "succeeded",
+          "type" => "documentAdditionOrUpdate",
+          "details" => %{
+            "receivedDocuments: 6748,
+            "indexedDocuments: 6743
+          },
           "duration" => 0.013233943,
           "enqueuedAt" => "2020-05-30T03:27:57.462943453Z",
-          "processedAt" => "2020-05-30T03:27:57.478393007Z",
-          "status" => "processed",
-          "type" => %{"name" => "DocumentsAddition", "number" => 1},
-          "updateId" => 0
+          "startedAt" => "2020-05-30T03:27:57.478393007Z",
+          "finishedAt" => "2020-05-30T03:27:57.578393007Z",
         }
       }
   """
-  @spec get(String.t(), String.t() | integer) :: HTTP.response()
-  def get(index_uid, update_id) do
-    HTTP.get_request("indexes/#{index_uid}/updates/#{update_id}")
+  @spec get(String.t() | integer) :: HTTP.response()
+  def get(update_id) do
+    HTTP.get_request("tasks/#{update_id}")
   end
 
   @doc """
-  Get the status of all updates for given index.
+  Get the status of all updates.
 
   ## Example
-      iex> Meilisearch.Updates.list("meilisearch_test")
+      iex> Meilisearch.Updates.list()
       {:ok,
-      [
-        %{
-          "duration" => 0.013233943,
-          "enqueuedAt" => "2020-05-30T03:27:57.462943453Z",
-          "processedAt" => "2020-05-30T03:27:57.478393007Z",
-          "status" => "processed",
-          "type" => %{"name" => "DocumentsAddition", "number" => 1},
-          "updateId" => 0
-        }
+        [
+          %{
+            "uid" => 2,
+            "indexUid" => "test_index",
+            "status" => "succeeded",
+            "type" => "documentAdditionOrUpdate",
+            "details" => %{
+              "receivedDocuments: 6748,
+              "indexedDocuments: 6743
+            },
+            "duration" => 0.013233943,
+            "enqueuedAt" => "2020-05-30T03:27:57.462943453Z",
+            "startedAt" => "2020-05-30T03:27:57.478393007Z",
+            "finishedAt" => "2020-05-30T03:27:57.578393007Z",
+          },
+          %{
+            "uid" => 1,
+            "indexUid" => "test_index",
+            "status" => "succeeded",
+            "type" => "documentAdditionOrUpdate",
+            "details" => %{
+              "receivedDocuments: 6748,
+              "indexedDocuments: 6743
+            },
+            "duration" => 0.013233943,
+            "enqueuedAt" => "2020-05-30T03:27:57.462943453Z",
+            "startedAt" => "2020-05-30T03:27:57.478393007Z",
+            "finishedAt" => "2020-05-30T03:27:57.578393007Z",
+          },
       ]}
   """
-  @spec list(String.t()) :: HTTP.response()
-  def list(index_uid) do
-    HTTP.get_request("indexes/#{index_uid}/updates")
+  @spec list() :: HTTP.response()
+  def list() do
+    case HTTP.get_request("tasks") do
+      {:ok, %{ "results" => updates }} -> {:ok, updates}
+      error -> error
+    end
   end
+
+  @doc """
+  Get the status of all updates for a given index.
+
+  ## Example
+      iex> Meilisearch.Updates.list(index_uid)
+      {:ok,
+        [
+          %{
+            "uid" => 2,
+            "indexUid" => "test_index",
+            "status" => "succeeded",
+            "type" => "documentAdditionOrUpdate",
+            "details" => %{
+              "receivedDocuments: 6748,
+              "indexedDocuments: 6743
+            },
+            "duration" => 0.013233943,
+            "enqueuedAt" => "2020-05-30T03:27:57.462943453Z",
+            "startedAt" => "2020-05-30T03:27:57.478393007Z",
+            "finishedAt" => "2020-05-30T03:27:57.578393007Z",
+          },
+          %{
+            "uid" => 1,
+            "indexUid" => "test_index",
+            "status" => "succeeded",
+            "type" => "documentAdditionOrUpdate",
+            "details" => %{
+              "receivedDocuments: 6748,
+              "indexedDocuments: 6743
+            },
+            "duration" => 0.013233943,
+            "enqueuedAt" => "2020-05-30T03:27:57.462943453Z",
+            "startedAt" => "2020-05-30T03:27:57.478393007Z",
+            "finishedAt" => "2020-05-30T03:27:57.578393007Z",
+          },
+      ]}
+  """
+  @spec list(String.t) :: HTTP.response()
+  def list(index_uid) do
+    case HTTP.get_request("tasks?indexUid=#{index_uid}") do
+      {:ok, %{ "results" => updates }} -> {:ok, updates}
+      error -> error
+    end
+  end
+
 end

--- a/lib/meilisearch/version.ex
+++ b/lib/meilisearch/version.ex
@@ -13,7 +13,7 @@ defmodule Meilisearch.Version do
   ## Example
 
       iex> Meilisearch.Version.get()
-      {:ok, %{"buildDate" => "2020-04-29T09:05:31.455410849+00:00", "commitSha" => "UNKNOWN", "pkgVersion" => "0.10.1"}}
+      {:ok, %{"commitDate" => "2020-04-29T09:05:31.455410849+00:00", "commitSha" => "UNKNOWN", "pkgVersion" => "0.10.1"}}
 
   """
   @spec get :: HTTP.response()

--- a/test/meilisearch/documents_test.exs
+++ b/test/meilisearch/documents_test.exs
@@ -25,17 +25,17 @@ defmodule Meilisearch.DocumentsTest do
   end
 
   test "Documents.add_or_replace" do
-    {:ok, update} = Documents.add_or_replace(@test_index, @test_document)
-    assert Map.has_key?(update, "updateId")
+    {:ok, task} = Documents.add_or_replace(@test_index, @test_document)
+    assert Map.has_key?(task, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(task, "taskUid"))
   end
 
   test "Documents.add_or_update" do
-    {:ok, update} = Documents.add_or_update(@test_index, @test_document)
-    assert Map.has_key?(update, "updateId")
+    {:ok, task} = Documents.add_or_update(@test_index, @test_document)
+    assert Map.has_key?(task, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(task, "taskUid"))
   end
 
   describe "existing document" do
@@ -55,7 +55,7 @@ defmodule Meilisearch.DocumentsTest do
     end
 
     test "Documents.list" do
-      {:ok, [document | _]} = Documents.list(@test_index)
+      {:ok, %{ "results" => [document | _] }} = Documents.list(@test_index)
 
       assert Map.get(document, "id") == 1
       assert Map.get(document, "title") == "Alien"

--- a/test/meilisearch/health_test.exs
+++ b/test/meilisearch/health_test.exs
@@ -5,7 +5,7 @@ defmodule Meilisearch.HealthTest do
 
   describe "Health.get" do
     test "returns `{:ok, _}` when instance is healthy" do
-      assert {:ok, _} = Health.get()
+      assert {:ok, %{ "status" => "available" }} = Health.get()
     end
   end
 

--- a/test/meilisearch/indexes_test.exs
+++ b/test/meilisearch/indexes_test.exs
@@ -1,7 +1,7 @@
 defmodule Meilisearch.IndexTest do
   use ExUnit.Case
-  alias Meilisearch.Indexes
-  import Support.Helpers, only: [{:wait_for_update, 1}]
+  alias Meilisearch.{Indexes, Updates}
+  import Support.Helpers, only: [{:wait_for_update, 1}, {:create_index, 1}]
 
   @test_index Meilisearch.Config.get(:test_index)
 
@@ -17,9 +17,7 @@ defmodule Meilisearch.IndexTest do
     end
 
     test "returns list of existing indexes" do
-      {:ok, %{ "taskUid" => update_id }} = Indexes.create(@test_index)
-
-      wait_for_update(update_id)
+      create_index(@test_index)
 
       assert {:ok, [index]} = Indexes.list()
       assert %{"createdAt" => _, "updatedAt" => _, "uid" => @test_index, "primaryKey" => nil} = index
@@ -28,9 +26,10 @@ defmodule Meilisearch.IndexTest do
 
   describe "Indexes.get" do
     test "returns index details" do
-      Indexes.create(@test_index)
+      create_index(@test_index)
+
       assert {:ok, index} = Indexes.get(@test_index)
-      assert %{"name" => @test_index, "uid" => @test_index, "primaryKey" => nil} = index
+      assert %{"uid" => @test_index, "primaryKey" => nil} = index
     end
 
     test "returns an error if index does not exist" do
@@ -40,52 +39,76 @@ defmodule Meilisearch.IndexTest do
 
   describe "Indexes.create" do
     test "creates a new index" do
-      assert {:ok, %{"name" => @test_index, "uid" => @test_index, "primaryKey" => nil}} =
-               Indexes.create(@test_index)
+      assert {:ok, %{ "taskUid" => update_id }} = Indexes.create(@test_index)
+    
+      wait_for_update(update_id)
+
+      assert {:ok, index} = Indexes.get(@test_index)
+      assert %{"uid" => @test_index, "primaryKey" => nil} = index
     end
 
     test "returns an error when given duplicate index uid" do
-      Indexes.create(@test_index)
-      assert {:error, 400, _} = Indexes.create(@test_index)
+      create_index(@test_index)
+
+      {:ok, %{ "taskUid" => update_id }} = Indexes.create(@test_index)
+
+      assert {:ok, %{ "error" => %{ "code" => "index_already_exists" }}} = Updates.get(update_id)
     end
 
     test "create new index with primary key if given" do
-      assert {:ok, %{"uid" => @test_index, "primaryKey" => "test_key"}} =
-               Indexes.create(@test_index, primary_key: "test_key")
+      assert {:ok, %{ "taskUid" => update_id }} = Indexes.create(@test_index, primary_key: "test_key")
+    
+      wait_for_update(update_id)
+
+      assert {:ok, index} = Indexes.get(@test_index)
+      assert %{"uid" => @test_index, "primaryKey" => "test_key"} = index
     end
   end
 
   describe "Indexes.update" do
     test "updates primary key" do
-      Indexes.create(@test_index)
-      Indexes.update(@test_index, primary_key: "new_primary_key")
+      create_index(@test_index)
+
+      {:ok, %{ "taskUid" => update_id }} = Indexes.update(@test_index, primary_key: "new_primary_key")
+      wait_for_update(update_id)
 
       assert {:ok, %{"primaryKey" => "new_primary_key"}} = Indexes.get(@test_index)
     end
 
     test "returns error if not given primary key" do
-      Indexes.create(@test_index)
+      create_index(@test_index)
 
       assert {:error, "primary_key is required"} = Indexes.update(@test_index)
     end
 
+    @tag :skip
     test "returns error if primary key is already set" do
-      Indexes.create(@test_index)
-      Indexes.update(@test_index, primary_key: "new_primary_key")
+      create_index(@test_index)
 
-      assert {:error, 400, _} = Indexes.update(@test_index, primary_key: "another_primary_key")
+      {:ok, %{ "taskUid" => update_id }} = Indexes.update(@test_index, primary_key: "new_primary_key")
+      wait_for_update(update_id)
+
+      {:ok, %{ "taskUid" => update_id }} = Indexes.update(@test_index, primary_key: "another_primary_key")
+      assert {:ok, %{ "status" => "failed" }} = wait_for_update(update_id)
+
+      # assert {:error, 400, _} = Indexes.update(@test_index, primary_key: "another_primary_key")
     end
   end
 
   describe "Indexes.delete" do
     test "deletes index and returns details" do
-      Indexes.create(@test_index)
-      assert {:ok, nil} = Indexes.delete(@test_index)
+      create_index(@test_index)
+
+      assert {:ok, %{ "taskUid" => update_id, "status" => "enqueued", "type" => "indexDeletion" }} = Indexes.delete(@test_index)
+      wait_for_update(update_id)
       assert {:ok, false} = Indexes.exists?(@test_index)
     end
 
     test "returns an error if index does not exist" do
-      assert {:error, 404, _} = Indexes.delete(@test_index)
+      assert {:ok, %{ "status" => "enqueued", "taskUid" => update_id }} = Indexes.delete(@test_index)
+
+      assert {:ok, %{ "error" => %{ "code" => "index_not_found" }}} = Updates.get(update_id)
+      #assert {:error, 404, _} = Indexes.delete(@test_index)
     end
   end
 
@@ -95,7 +118,8 @@ defmodule Meilisearch.IndexTest do
     end
 
     test "returns true if index exists" do
-      Indexes.create(@test_index)
+      create_index(@test_index)
+
       assert {:ok, true} = Indexes.exists?(@test_index)
     end
   end

--- a/test/meilisearch/indexes_test.exs
+++ b/test/meilisearch/indexes_test.exs
@@ -1,6 +1,6 @@
 defmodule Meilisearch.IndexTest do
   use ExUnit.Case
-  alias Meilisearch.{Indexes, Updates}
+  alias Meilisearch.{Indexes, Tasks}
   import Support.Helpers, only: [{:wait_for_update, 1}, {:create_index, 1}]
 
   @test_index Meilisearch.Config.get(:test_index)
@@ -52,7 +52,7 @@ defmodule Meilisearch.IndexTest do
 
       {:ok, %{ "taskUid" => update_id }} = Indexes.create(@test_index)
 
-      assert {:ok, %{ "error" => %{ "code" => "index_already_exists" }}} = Updates.get(update_id)
+      assert {:ok, %{ "error" => %{ "code" => "index_already_exists" }}} = Tasks.get(update_id)
     end
 
     test "create new index with primary key if given" do
@@ -66,7 +66,7 @@ defmodule Meilisearch.IndexTest do
   end
 
   describe "Indexes.update" do
-    test "updates primary key" do
+    test "Tasks primary key" do
       create_index(@test_index)
 
       {:ok, %{ "taskUid" => update_id }} = Indexes.update(@test_index, primary_key: "new_primary_key")
@@ -107,7 +107,7 @@ defmodule Meilisearch.IndexTest do
     test "returns an error if index does not exist" do
       assert {:ok, %{ "status" => "enqueued", "taskUid" => update_id }} = Indexes.delete(@test_index)
 
-      assert {:ok, %{ "error" => %{ "code" => "index_not_found" }}} = Updates.get(update_id)
+      assert {:ok, %{ "error" => %{ "code" => "index_not_found" }}} = Tasks.get(update_id)
       #assert {:error, 404, _} = Indexes.delete(@test_index)
     end
   end

--- a/test/meilisearch/indexes_test.exs
+++ b/test/meilisearch/indexes_test.exs
@@ -1,6 +1,7 @@
 defmodule Meilisearch.IndexTest do
   use ExUnit.Case
   alias Meilisearch.Indexes
+  import Support.Helpers, only: [{:wait_for_update, 1}]
 
   @test_index Meilisearch.Config.get(:test_index)
 
@@ -16,10 +17,12 @@ defmodule Meilisearch.IndexTest do
     end
 
     test "returns list of existing indexes" do
-      Indexes.create(@test_index)
+      {:ok, %{ "taskUid" => update_id }} = Indexes.create(@test_index)
+
+      wait_for_update(update_id)
 
       assert {:ok, [index]} = Indexes.list()
-      assert %{"name" => @test_index, "uid" => @test_index, "primaryKey" => nil} = index
+      assert %{"createdAt" => _, "updatedAt" => _, "uid" => @test_index, "primaryKey" => nil} = index
     end
   end
 

--- a/test/meilisearch/indexes_test.exs
+++ b/test/meilisearch/indexes_test.exs
@@ -6,7 +6,8 @@ defmodule Meilisearch.IndexTest do
   @test_index Meilisearch.Config.get(:test_index)
 
   setup do
-    Indexes.delete(@test_index)
+    {:ok, %{ "taskUid" => task_id }} = Indexes.delete(@test_index)
+    wait_for_update(task_id)
 
     :ok
   end
@@ -52,7 +53,7 @@ defmodule Meilisearch.IndexTest do
 
       {:ok, %{ "taskUid" => update_id }} = Indexes.create(@test_index)
 
-      assert {:ok, %{ "error" => %{ "code" => "index_already_exists" }}} = Tasks.get(update_id)
+      assert {:ok, %{ "error" => %{ "code" => "index_already_exists" }}} = wait_for_update(update_id)
     end
 
     test "create new index with primary key if given" do
@@ -106,6 +107,7 @@ defmodule Meilisearch.IndexTest do
 
     test "results in an error if index does not exist" do
       assert {:ok, %{ "status" => "enqueued", "taskUid" => update_id }} = Indexes.delete(@test_index)
+      wait_for_update(update_id)
 
       assert {:ok, %{ "error" => %{ "code" => "index_not_found" }}} = Tasks.get(update_id)
     end

--- a/test/meilisearch/indexes_test.exs
+++ b/test/meilisearch/indexes_test.exs
@@ -82,8 +82,8 @@ defmodule Meilisearch.IndexTest do
       assert {:error, "primary_key is required"} = Indexes.update(@test_index)
     end
 
-    @tag :skip
-    test "returns error if primary key is already set" do
+    @tag :skip # No error results if no documents exist in index
+    test "results in an error if primary key is already set" do
       create_index(@test_index)
 
       {:ok, %{ "taskUid" => update_id }} = Indexes.update(@test_index, primary_key: "new_primary_key")
@@ -91,8 +91,6 @@ defmodule Meilisearch.IndexTest do
 
       {:ok, %{ "taskUid" => update_id }} = Indexes.update(@test_index, primary_key: "another_primary_key")
       assert {:ok, %{ "status" => "failed" }} = wait_for_update(update_id)
-
-      # assert {:error, 400, _} = Indexes.update(@test_index, primary_key: "another_primary_key")
     end
   end
 

--- a/test/meilisearch/indexes_test.exs
+++ b/test/meilisearch/indexes_test.exs
@@ -104,11 +104,10 @@ defmodule Meilisearch.IndexTest do
       assert {:ok, false} = Indexes.exists?(@test_index)
     end
 
-    test "returns an error if index does not exist" do
+    test "results in an error if index does not exist" do
       assert {:ok, %{ "status" => "enqueued", "taskUid" => update_id }} = Indexes.delete(@test_index)
 
       assert {:ok, %{ "error" => %{ "code" => "index_not_found" }}} = Tasks.get(update_id)
-      #assert {:error, 404, _} = Indexes.delete(@test_index)
     end
   end
 

--- a/test/meilisearch/keys_test.exs
+++ b/test/meilisearch/keys_test.exs
@@ -3,11 +3,12 @@ defmodule Meilisearch.KeysTest do
   alias Meilisearch.Keys
 
   test "Keys.get returns public and private keys" do
-    assert {
-             :ok,
+    assert { :ok,
              %{
-               "private" => _,
-               "public" => _
+               "results" => [
+                 %{ "actions" => [ "search" ] },
+                 %{ "actions" => [ "*" ] }
+               ]
              }
            } = Keys.get()
   end

--- a/test/meilisearch/search_test.exs
+++ b/test/meilisearch/search_test.exs
@@ -20,6 +20,7 @@ defmodule Meilisearch.SearchTest do
   setup do
     Indexes.delete(@test_index)
     Indexes.create(@test_index)
+    Settings.update_filterable_attributes(@test_index, ["id"])
     Documents.add_or_replace(@test_index, @test_documents)
 
     on_exit(fn ->
@@ -39,9 +40,6 @@ defmodule Meilisearch.SearchTest do
       assert Map.get(hit, "title") == "The Thing"
     end
 
-    # Settings module needs to be updated first before we can test this - 
-    # we need to update filterable-attributes before it happens
-    @tag :skip 
     test "placeholder search should return matching results" do
       {:ok, %{"hits" => [hit]}} = Search.search(@test_index, nil, filter: "id = 1")
 

--- a/test/meilisearch/search_test.exs
+++ b/test/meilisearch/search_test.exs
@@ -33,7 +33,7 @@ defmodule Meilisearch.SearchTest do
 
   describe "Search.search" do
     test "should return matching results" do
-      {:ok, %{"results" => [hit]}} = Search.search(@test_index, "warmest")
+      {:ok, %{"hits" => [hit]}} = Search.search(@test_index, "warmest")
 
       assert Map.get(hit, "id") == 2
       assert Map.get(hit, "title") == "The Thing"

--- a/test/meilisearch/search_test.exs
+++ b/test/meilisearch/search_test.exs
@@ -1,7 +1,7 @@
 defmodule Meilisearch.SearchTest do
   use ExUnit.Case
 
-  alias Meilisearch.{Documents, Indexes, Search}
+  alias Meilisearch.{Documents, Indexes, Search, Settings}
 
   @test_index Meilisearch.Config.get(:test_index)
   @test_documents [
@@ -33,14 +33,17 @@ defmodule Meilisearch.SearchTest do
 
   describe "Search.search" do
     test "should return matching results" do
-      {:ok, %{"hits" => [hit]}} = Search.search(@test_index, "warmest")
+      {:ok, %{"results" => [hit]}} = Search.search(@test_index, "warmest")
 
       assert Map.get(hit, "id") == 2
       assert Map.get(hit, "title") == "The Thing"
     end
 
+    # Settings module needs to be updated first before we can test this - 
+    # we need to update filterable-attributes before it happens
+    @tag :skip 
     test "placeholder search should return matching results" do
-      {:ok, %{"hits" => [hit]}} = Search.search(@test_index, nil, filters: "id = 1")
+      {:ok, %{"hits" => [hit]}} = Search.search(@test_index, nil, filter: "id = 1")
 
       assert Map.get(hit, "id") == 1
       assert Map.get(hit, "title") == "Alien"

--- a/test/meilisearch/settings_test.exs
+++ b/test/meilisearch/settings_test.exs
@@ -8,7 +8,8 @@ defmodule Meilisearch.SettingsTest do
   @synonyms %{alien: ["ufo"]}
   @stop_words ["the", "of", "to"]
   @ranking_rules ["typo", "words", "proximity", "attribute"]
-  @attributes_for_faceting ["title"]
+  @filterable_attributes ["title"]
+  @faceting %{ maxValuesPerFacet: 4 }
   @distinct_attribute "id"
   @searchable_attributes ["title"]
   @displayed_attributes ["title"]
@@ -30,7 +31,8 @@ defmodule Meilisearch.SettingsTest do
     {:ok, settings} = Settings.get(@test_index)
 
     assert Map.has_key?(settings, "rankingRules")
-    assert Map.has_key?(settings, "attributesForFaceting")
+    assert Map.has_key?(settings, "filterableAttributes")
+    assert Map.has_key?(settings, "faceting")
     assert Map.has_key?(settings, "displayedAttributes")
     assert Map.has_key?(settings, "distinctAttribute")
     assert Map.has_key?(settings, "searchableAttributes")
@@ -40,16 +42,16 @@ defmodule Meilisearch.SettingsTest do
 
   test "Settings.update" do
     {:ok, update} = Settings.update(@test_index, %{synonyms: @synonyms})
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.reset" do
     {:ok, update} = Settings.reset(@test_index)
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.get_synonyms" do
@@ -59,16 +61,16 @@ defmodule Meilisearch.SettingsTest do
 
   test "Settings.update_synonyms" do
     {:ok, update} = Settings.update_synonyms(@test_index, @synonyms)
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.reset_synonyms" do
     {:ok, update} = Settings.reset_synonyms(@test_index)
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.get_stop_words" do
@@ -78,67 +80,90 @@ defmodule Meilisearch.SettingsTest do
 
   test "Settings.update_stop_words" do
     {:ok, update} = Settings.update_stop_words(@test_index, @stop_words)
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.reset_stop_words" do
     {:ok, update} = Settings.reset_stop_words(@test_index)
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.get_ranking_rules" do
     {:ok, ranking_rules} = Settings.get_ranking_rules(@test_index)
 
     assert ranking_rules == [
-             "typo",
              "words",
+             "typo",
              "proximity",
              "attribute",
-             "wordsPosition",
+             "sort",
              "exactness"
            ]
   end
 
   test "Settings.update_ranking_rules" do
     {:ok, update} = Settings.update_ranking_rules(@test_index, @ranking_rules)
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.reset_ranking_rules" do
     {:ok, update} = Settings.reset_ranking_rules(@test_index)
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
-  test "Settings.get_attributes_for_faceting" do
-    {:ok, attributes_for_faceting} = Settings.get_attributes_for_faceting(@test_index)
-    assert attributes_for_faceting == []
+  test "Settings.get_faceting" do
+    assert {:ok, %{ "maxValuesPerFacet" => _ }} = Settings.get_faceting(@test_index)
   end
 
-  test "Settings.update_attributes_for_faceting" do
+  test "Settings.update_faceting" do
     {:ok, update} =
-      Settings.update_attributes_for_faceting(
+      Settings.update_faceting(
         @test_index,
-        @attributes_for_faceting
+        @faceting
       )
 
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
-  test "Settings.reset_attributes_for_faceting" do
-    {:ok, update} = Settings.reset_attributes_for_faceting(@test_index)
-    assert Map.has_key?(update, "updateId")
+  test "Settings.reset_faceting" do
+    {:ok, update} = Settings.reset_faceting(@test_index)
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
+  end
+
+  test "Settings.get_filterable_attributes" do
+    {:ok, filterable_attributes} = Settings.get_filterable_attributes(@test_index)
+    assert filterable_attributes == []
+  end
+
+  test "Settings.update_filterable_attributes" do
+    {:ok, update} =
+      Settings.update_filterable_attributes(
+        @test_index,
+        @filterable_attributes
+      )
+
+    assert Map.has_key?(update, "taskUid")
+
+    wait_for_update(Map.get(update, "taskUid"))
+  end
+
+  test "Settings.reset_filterable_attributes" do
+    {:ok, update} = Settings.reset_filterable_attributes(@test_index)
+    assert Map.has_key?(update, "taskUid")
+
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.get_distinct_attribute" do
@@ -153,16 +178,16 @@ defmodule Meilisearch.SettingsTest do
         @distinct_attribute
       )
 
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.reset_distinct_attribute" do
     {:ok, update} = Settings.reset_distinct_attribute(@test_index)
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.get_searchable_attributes" do
@@ -177,16 +202,16 @@ defmodule Meilisearch.SettingsTest do
         @searchable_attributes
       )
 
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.reset_searchable_attributes" do
     {:ok, update} = Settings.reset_searchable_attributes(@test_index)
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.get_displayed_attributes" do
@@ -201,15 +226,15 @@ defmodule Meilisearch.SettingsTest do
         @displayed_attributes
       )
 
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 
   test "Settings.reset_displayed_attributes" do
     {:ok, update} = Settings.reset_displayed_attributes(@test_index)
-    assert Map.has_key?(update, "updateId")
+    assert Map.has_key?(update, "taskUid")
 
-    wait_for_update(@test_index, Map.get(update, "updateId"))
+    wait_for_update(Map.get(update, "taskUid"))
   end
 end

--- a/test/meilisearch/stats_test.exs
+++ b/test/meilisearch/stats_test.exs
@@ -1,5 +1,6 @@
 defmodule Meilisearch.StatsTest do
   use ExUnit.Case
+  import Support.Helpers, only: [{:create_index, 1}]
 
   alias Meilisearch.{Indexes, Stats}
 
@@ -12,14 +13,15 @@ defmodule Meilisearch.StatsTest do
   end
 
   test "get returns stats for given index" do
-    Indexes.create(@test_index)
+    create_index(@test_index)
 
-    assert {:ok, %{"fieldsDistribution" => _, "isIndexing" => _, "numberOfDocuments" => _}} =
+    assert {:ok, %{"fieldDistribution" => _, "isIndexing" => _, "numberOfDocuments" => _}} =
              Stats.get(@test_index)
   end
 
   test "get_all returns stats for all indexes" do
-    Indexes.create(@test_index)
+    create_index(@test_index)
+
     assert {:ok, %{"databaseSize" => _, "indexes" => %{@test_index => _}}} = Stats.list()
   end
 end

--- a/test/meilisearch/tasks_test.exs
+++ b/test/meilisearch/tasks_test.exs
@@ -20,7 +20,7 @@ defmodule Meilisearch.TasksTest do
     :ok
   end
 
-  describe "Updates.get" do
+  describe "Tasks.get" do
     test "returns error, 404 with invalid update id" do
       {:error, status_code, message} = Tasks.get(10_071_982)
 
@@ -41,7 +41,7 @@ defmodule Meilisearch.TasksTest do
     end
   end
 
-  test "Updates.list returns list of updates" do
+  test "Tasks.list returns list of tasks" do
     Documents.add_or_replace(@test_index, [@test_document])
     {:ok, [update | _]} = Tasks.list(@test_index)
 

--- a/test/meilisearch/tasks_test.exs
+++ b/test/meilisearch/tasks_test.exs
@@ -1,6 +1,6 @@
-defmodule Meilisearch.UpdatesTest do
+defmodule Meilisearch.TasksTest do
   use ExUnit.Case
-  alias Meilisearch.{Documents, Indexes, Updates}
+  alias Meilisearch.{Documents, Indexes, Tasks}
 
   @test_index Meilisearch.Config.get(:test_index)
   @test_document %{
@@ -22,34 +22,34 @@ defmodule Meilisearch.UpdatesTest do
 
   describe "Updates.get" do
     test "returns error, 404 with invalid update id" do
-      {:error, status_code, message} = Updates.get(@test_index, 10_071_982)
+      {:error, status_code, message} = Tasks.get(10_071_982)
 
       assert status_code == 404
       assert is_binary(message)
     end
 
     test "returns update status" do
-      {:ok, %{"updateId" => update_id}} = Documents.add_or_replace(@test_index, [@test_document])
+      {:ok, %{"taskUid" => task_id}} = Documents.add_or_replace(@test_index, [@test_document])
 
       assert {:ok,
               %{
                 "enqueuedAt" => _,
                 "status" => _,
                 "type" => _,
-                "updateId" => _
-              }} = Updates.get(@test_index, update_id)
+                "uid" => _
+              }} = Tasks.get(task_id)
     end
   end
 
   test "Updates.list returns list of updates" do
     Documents.add_or_replace(@test_index, [@test_document])
-    {:ok, [update | _]} = Updates.list(@test_index)
+    {:ok, [update | _]} = Tasks.list(@test_index)
 
     assert %{
              "enqueuedAt" => _,
              "status" => _,
              "type" => _,
-             "updateId" => _
+             "uid" => _
            } = update
   end
 end

--- a/test/meilisearch/tasks_test.exs
+++ b/test/meilisearch/tasks_test.exs
@@ -52,4 +52,10 @@ defmodule Meilisearch.TasksTest do
              "uid" => _
            } = update
   end
+
+  test "Tasks.await_result waits for a finalized task" do
+    {:ok, %{"taskUid" => task_id}} = Documents.add_or_replace(@test_index, [@test_document])
+    assert {:ok, %{ "status" => "enqueued" }} = Tasks.get(task_id)
+    assert {:ok, %{ "status" => "succeeded" }} = Tasks.await_result(task_id)
+  end
 end

--- a/test/meilisearch/version_test.exs
+++ b/test/meilisearch/version_test.exs
@@ -4,6 +4,6 @@ defmodule Meilisearch.VersionTest do
   alias Meilisearch.Version
 
   test "version returns version infomation" do
-    assert {:ok, %{"buildDate" => _, "commitSha" => _, "pkgVersion" => _}} = Version.get()
+    assert {:ok, %{"commitDate" => _, "commitSha" => _, "pkgVersion" => _}} = Version.get()
   end
 end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -11,20 +11,7 @@ defmodule Support.Helpers do
     |> Enum.map(&Indexes.delete/1)
   end
 
-  def wait_for_update(update_id) do
-    case Tasks.get(update_id) do
-      {:ok, %{"status" => "enqueued"}} ->
-        :timer.sleep(500)
-        wait_for_update(update_id)
-      {:ok, %{"status" => "processing"}} ->
-        :timer.sleep(500)
-        wait_for_update(update_id)
-
-      message ->
-        :timer.sleep(200)
-        message
-    end
-  end
+  def wait_for_update(update_id), do: Tasks.await_result(update_id)
 
   def create_index(uid, opts \\ []) do
     {:ok, %{"taskUid" => update_id}} = Indexes.create(uid, opts)

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -17,8 +17,14 @@ defmodule Support.Helpers do
         :timer.sleep(500)
         wait_for_update(update_id)
 
-      _ ->
-        :timer.sleep(500)
+      message ->
+        :timer.sleep(200)
+        message
     end
+  end
+
+  def create_index(uid, opts \\ []) do
+    {:ok, %{"taskUid" => update_id}} = Indexes.create(uid, opts)
+    wait_for_update(update_id)
   end
 end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -4,18 +4,18 @@ defmodule Support.Helpers do
   alias Meilisearch.{Indexes, Updates}
 
   def delete_all_indexes do
-    {:ok, %{ "results" => indexes }} = Indexes.list()
+    {:ok, indexes} = Indexes.list()
 
     indexes
     |> Enum.map(fn %{"uid" => uid} -> uid end)
     |> Enum.map(&Indexes.delete/1)
   end
 
-  def wait_for_update(index_uid, update_id) do
-    case Updates.get(index_uid, update_id) do
+  def wait_for_update(update_id) do
+    case Updates.get(update_id) do
       {:ok, %{"status" => "enqueued"}} ->
         :timer.sleep(500)
-        wait_for_update(index_uid, update_id)
+        wait_for_update(update_id)
 
       _ ->
         :timer.sleep(500)

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -16,6 +16,9 @@ defmodule Support.Helpers do
       {:ok, %{"status" => "enqueued"}} ->
         :timer.sleep(500)
         wait_for_update(update_id)
+      {:ok, %{"status" => "processing"}} ->
+        :timer.sleep(500)
+        wait_for_update(update_id)
 
       message ->
         :timer.sleep(200)

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -1,7 +1,7 @@
 defmodule Support.Helpers do
   @moduledoc false
 
-  alias Meilisearch.{Indexes, Updates}
+  alias Meilisearch.{Indexes, Tasks}
 
   def delete_all_indexes do
     {:ok, indexes} = Indexes.list()
@@ -12,7 +12,7 @@ defmodule Support.Helpers do
   end
 
   def wait_for_update(update_id) do
-    case Updates.get(update_id) do
+    case Tasks.get(update_id) do
       {:ok, %{"status" => "enqueued"}} ->
         :timer.sleep(500)
         wait_for_update(update_id)

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -4,7 +4,7 @@ defmodule Support.Helpers do
   alias Meilisearch.{Indexes, Updates}
 
   def delete_all_indexes do
-    {:ok, indexes} = Indexes.list()
+    {:ok, %{ "results" => indexes }} = Indexes.list()
 
     indexes
     |> Enum.map(fn %{"uid" => uid} -> uid end)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.start()
+ExUnit.start(exclude: [:skip])
 
 %{
   host: host,


### PR DESCRIPTION
Updates Meilisearch-Elixir to be compatible with Meilisearch 0.28, which otherwise has some breaking changes around faceting in Settings, as well as now enqueues most tasks (making it necessary to have a formal utility to await for Task resolution).

In summary:
- Replaces `Updates` module with `Tasks` module to reflect MS API.
- Updates documentation and tests to reflect methods that now return `Tasks` instead of finalized statuses.
- Updates `Settings` to reflect changes from `facetableAttributes` to `filterableAttributes`, and adds `facet` as a setting.
- Adds `await_result` method to `Tasks` module, making it part of the formal API.
- Updates `config` to use the new `Config` module.
- Updates some HTTP methods that were not interacting correctly with Meilisearch (mainly `post` requests -> `put` or `patch`).