### PR TITLE
Allow endpoint to be configured at runtime and support connect_options

### DIFF
--- a/lib/meilisearch/config.ex
+++ b/lib/meilisearch/config.ex
@@ -5,6 +5,7 @@ defmodule Meilisearch.Config do
 
   @default_endpoint "http://127.0.0.1:7700"
   @default_api_key ""
+  @default_connect_options []
 
   @spec endpoint :: String.t()
   def endpoint do
@@ -14,6 +15,10 @@ defmodule Meilisearch.Config do
   @spec api_key :: String.t()
   def api_key do
     get(:api_key, @default_api_key)
+  end
+
+  def connect_options do
+    get(:connect_options, @default_connect_options)
   end
 
   @spec get(atom, String.t()) :: nil | String.t()

--- a/lib/meilisearch/config.ex
+++ b/lib/meilisearch/config.ex
@@ -18,7 +18,7 @@ defmodule Meilisearch.Config do
   end
 
   def connect_options do
-    get(:connect_options, @default_connect_options)
+    Application.get_env(:meilisearch, :connect_options, @default_connect_options)
   end
 
   @spec get(atom, String.t()) :: nil | String.t()

--- a/lib/meilisearch/http.ex
+++ b/lib/meilisearch/http.ex
@@ -10,7 +10,10 @@ defmodule Meilisearch.HTTP do
 
   @type response :: success | error
 
-  @req Req.new(base_url: Meilisearch.Config.endpoint())
+  @req Req.new(
+         base_url: Meilisearch.Config.endpoint(),
+         connect_options: Meilisearch.Config.connect_options()
+       )
 
   # Client API
 

--- a/lib/meilisearch/http.ex
+++ b/lib/meilisearch/http.ex
@@ -10,41 +10,48 @@ defmodule Meilisearch.HTTP do
 
   @type response :: success | error
 
-  @req Req.new(
-         base_url: Meilisearch.Config.endpoint(),
-         connect_options: Meilisearch.Config.connect_options()
-       )
-
   # Client API
 
   @spec get_request(String.t(), Keyword.t()) :: response()
   def get_request(url, params \\ []) do
-    Req.get(@req, url: url, headers: build_headers(), params: params)
+    client()
+    |> Req.get(url: url, headers: build_headers(), params: params)
     |> handle_response()
   end
 
   @spec put_request(String.t(), any, Keyword.t()) :: response()
   def put_request(url, body, params \\ []) do
-    Req.put(@req, url: url, headers: build_headers(), json: body, params: params)
+    client()
+    |> Req.put(url: url, headers: build_headers(), json: body, params: params)
     |> handle_response()
   end
 
   @spec patch_request(String.t(), any, Keyword.t()) :: response()
   def patch_request(url, body, params \\ []) do
-    Req.patch(@req, url: url, headers: build_headers(), json: body, params: params)
+    client()
+    |> Req.patch(url: url, headers: build_headers(), json: body, params: params)
     |> handle_response()
   end
 
   @spec post_request(String.t(), any, Keyword.t()) :: response()
   def post_request(url, body, params \\ []) do
-    Req.post(@req, url: url, headers: build_headers(), json: body, params: params)
+    client()
+    |> Req.post(url: url, headers: build_headers(), json: body, params: params)
     |> handle_response()
   end
 
   @spec delete_request(String.t(), Keyword.t()) :: response()
   def delete_request(url, params \\ []) do
-    Req.delete(@req, url: url, headers: build_headers(), params: params)
+    client()
+    |> Req.delete(url: url, headers: build_headers(), params: params)
     |> handle_response()
+  end
+
+  def client do
+    Req.new(
+      base_url: Meilisearch.Config.endpoint(),
+      connect_options: Meilisearch.Config.connect_options()
+    )
   end
 
   # Utils


### PR DESCRIPTION
We just updated to master and noticed a few regressions in networking during the switch to using the Req library. This PR fixes the issues we hit.

1. Endpoint configuration:

  We set this at runtime from env vars. something like  `config :meilisearch, endpoint: env_var.("MEILISEARCH_ENDPOINT")` unfortunately the code in master does `@req Req.new(base_url: Meilisearch.Config.endpoint())` so the endpoint value gets baked to whatever was set at compile time.

2. connect_options support:

  We are running on fly.io and wish to communicate with meillisearch over their private ipv6 network, this used to work but not on master. It looks like Req is using Mint under the hood. Mint seems to require setting `connect_options: [transport_opts: [inet6: true]]` to enable ipv6 support. This change PR allows you to pass connect_options in app config. E.g. `config :meilisearch, connect_options: [transport_opts: [inet6: true]]`

We are using both these changes in production currently and it would be great to them (or similar) in the next release.
